### PR TITLE
drivers: sense: Add synapse_pb dependency

### DIFF
--- a/drivers/sense/baro/CMakeLists.txt
+++ b/drivers/sense/baro/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) 2025 Croxel Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(zros_sense_baro)
+add_dependencies(zros_sense_baro synapse_pb)
 zephyr_library_sources(
 	main.c
 )

--- a/drivers/sense/imu/CMakeLists.txt
+++ b/drivers/sense/imu/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) 2025 Croxel Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(zros_sense_imu)
+add_dependencies(zros_sense_imu synapse_pb)
 zephyr_library_sources(
 	main.c
 )

--- a/drivers/sense/mag/CMakeLists.txt
+++ b/drivers/sense/mag/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) 2025 Croxel Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
+zephyr_library_named(zros_sense_mag)
+add_dependencies(zros_sense_mag synapse_pb)
 zephyr_library_sources(
 	main.c
 )


### PR DESCRIPTION
As reported by the CogniPilot team, if this is missing there's a race condition during CMake build. It was in the previous driver in cerebri but I missed it.