### PR TITLE
drivers: sense: imu: add DRDY streaming mode option

### DIFF
--- a/drivers/sense/stream/imu/Kconfig
+++ b/drivers/sense/stream/imu/Kconfig
@@ -13,6 +13,18 @@ config ZROS_SENSE_STREAM_IMU
 
 if ZROS_SENSE_STREAM_IMU
 
+config ZROS_SENSE_STREAM_IMU_DRDY_MODE
+	bool "Use DRDY trigger instead of FIFO watermark"
+	default n
+	help
+	  When enabled, the IMU stream driver uses SENSOR_TRIG_DATA_READY
+	  instead of SENSOR_TRIG_FIFO_WATERMARK. This provides lower latency
+	  by reading samples directly from the sensor data registers on each
+	  data-ready interrupt, bypassing the FIFO.
+
+	  Note: The sensor driver must support DRDY-based streaming for this
+	  to work (e.g., ICM4268X with interrupt1-drdy enabled in devicetree).
+
 module = ZROS_SENSE_STREAM_IMU
 module-str = sense_stream_imu
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/sense/stream/imu/main.c
+++ b/drivers/sense/stream/imu/main.c
@@ -407,11 +407,17 @@ static void imu_stream_thread(void *arg0)
 	}
 }
 
+#if IS_ENABLED(CONFIG_ZROS_SENSE_STREAM_IMU_DRDY_MODE)
+#define IMU_STREAM_TRIGGER SENSOR_TRIG_DATA_READY
+#else
+#define IMU_STREAM_TRIGGER SENSOR_TRIG_FIFO_WATERMARK
+#endif
+
 #define IMU_STREAM_DEFINE(i)									   \
 												   \
 RTIO_DEFINE_WITH_MEMPOOL(imu_stream_ctx_##i, 2, 4, 128, 4, sizeof(void *));			   \
 SENSOR_DT_STREAM_IODEV(imu_stream_iodev_##i, IMU_ALIAS(i),					   \
-		       {SENSOR_TRIG_FIFO_WATERMARK, SENSOR_STREAM_DATA_INCLUDE});		   \
+		       {IMU_STREAM_TRIGGER, SENSOR_STREAM_DATA_INCLUDE});		   \
 												   \
 static struct context imu_stream_context_##i = {						   \
 	.name = STRINGIFY(sense_imu_##i),							   \


### PR DESCRIPTION
Add CONFIG_ZROS_SENSE_STREAM_IMU_DRDY_MODE Kconfig option to select between FIFO watermark and Data Ready (DRDY) trigger modes.

When enabled, the IMU stream driver uses SENSOR_TRIG_DATA_READY instead of SENSOR_TRIG_FIFO_WATERMARK. This provides lower latency by reading samples directly from the sensor data registers on each data-ready interrupt, bypassing the FIFO.

The sensor driver must support DRDY-based streaming for this to work (e.g., ICM4268X with interrupt1-drdy enabled in devicetree).